### PR TITLE
Pin gcloud to version < 0.6 for jruby 1.7 compat

### DIFF
--- a/logstash-input-google-cloud-pubsub.gemspec
+++ b/logstash-input-google-cloud-pubsub.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", ">= 2.0.0", "< 3.0.0"
-  s.add_runtime_dependency 'gcloud'
+  s.add_runtime_dependency 'gcloud', '< 0.6'
   s.add_runtime_dependency 'stud', '>= 0.0.22'
   s.add_development_dependency 'logstash-devutils', '>= 0.0.16'
 end


### PR DESCRIPTION
logstash bundles jruby 1.7 which is not ruby 2.0 compatible. The gcloud gem starting at version 0.6 requires at least ruby 2.0 which makes this plugin fail during installation.

This fixes #1 
